### PR TITLE
added some tests, added Response wrapper object

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "NetworkKit",
-            targets: ["NetworkKit"]),
+            targets: ["NetworkKit"]
+        ),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -20,9 +21,11 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "NetworkKit",
-            dependencies: []),
+            dependencies: []
+        ),
         .testTarget(
             name: "NetworkKitTests",
-            dependencies: ["NetworkKit"]),
+            dependencies: ["NetworkKit"]
+        ),
     ]
 )

--- a/Sources/NetworkKit/Endpoint.swift
+++ b/Sources/NetworkKit/Endpoint.swift
@@ -13,9 +13,9 @@ public enum HTTPMethod: String {
     case post
     case put
     case delete
-    
+
     var value: String {
-        return self.rawValue.uppercased()
+        return rawValue.uppercased()
     }
 }
 
@@ -29,21 +29,33 @@ public enum NetworkStackError: Error {
 }
 
 public typealias HTTPHeaders = [String: String]
+public typealias ResultRequestCallback<T> = (Response<T, NetworkStackError>) -> Void
 public typealias ResultDecodableCallback<T> = (Result<T, NetworkStackError>) -> Void
-public typealias ResultDataCallback = (Result<Data, NetworkStackError>) -> Void
+public typealias ResultDataCallback = (URLRequest?, URLResponse?, Result<Data, NetworkStackError>) -> Void
 public typealias ResultStatusCodeCallBack = (Result<Int, NetworkStackError>) -> Void
-public typealias QueryParameters = [String : String]
+public typealias QueryParameters = [String: String]
 public typealias TaskCallback = (Data?, URLResponse?, Error?) -> Void
 
 public enum ResponseType {
-    
     case statusCode
     case data
     case codable
 }
 
-public enum HTTPBodyType{
+public enum HTTPBodyType {
     case json
     case formEncoded(parameters: [String: String])
     case none
+}
+
+public struct Response<Success, Failure: Error> {
+    public let request: URLRequest?
+    public let response: URLResponse?
+    public let data: Data?
+    public let result: Result<Success, Failure>
+    public var value: Success? { return try? result.get() }
+    public var error: Failure? {
+        guard case let .failure(error) = result else { return nil }
+        return error
+    }
 }

--- a/Sources/NetworkKit/NetworkActivity.swift
+++ b/Sources/NetworkKit/NetworkActivity.swift
@@ -14,21 +14,19 @@ public protocol NetworkActivityProtocol {
 }
 
 public class NetworkActivity: NetworkActivityProtocol {
-    public init() {
-        
-    }
+    public init() {}
+
     private var acitivityCount = 0 {
         didSet {
             UIApplication.shared.isNetworkActivityIndicatorVisible = (acitivityCount > 0)
         }
     }
-    
+
     public func increment() {
         OperationQueue.main.addOperation { self.acitivityCount += 1 }
     }
-    
+
     public func decrement() {
         OperationQueue.main.addOperation { self.acitivityCount -= 1 }
     }
 }
-

--- a/Sources/NetworkKit/Parser.swift
+++ b/Sources/NetworkKit/Parser.swift
@@ -9,21 +9,20 @@
 import Foundation
 
 public protocol ParserProtocol {
-    func json<T: Decodable>(data: Data, completion: @escaping ResultDecodableCallback<T>)
+    func json<T: Decodable>(data: Data?) -> Result<T, NetworkStackError>
 }
 
 public class Parser: ParserProtocol {
     let jsonDecoder = JSONDecoder()
-    public init() {
+    public init() {}
+
+    public func json<T: Decodable>(data: Data?) -> Result<T, NetworkStackError> {
+        guard let data = data else {
+            return .failure(NetworkStackError.dataMissing)
+        }
         
-    }
-    
-    public func json<T: Decodable>(data: Data, completion: @escaping ResultDecodableCallback<T>) {
-        do {
-            let result: T = try jsonDecoder.decode(T.self, from: data)
-            OperationQueue.main.addOperation {completion(.success(result))}
-        }catch {
-            OperationQueue.main.addOperation {completion(.failure(.paringError(error)))}
+        return Result { try jsonDecoder.decode(T.self, from: data) }.mapError { error in
+            NetworkStackError.paringError(error)
         }
     }
 }

--- a/Sources/NetworkKit/URLComponent.swift
+++ b/Sources/NetworkKit/URLComponent.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public extension URLComponents {
     mutating func setQueryItems(with parameters: QueryParameters) {
-        self.queryItems = parameters.map{ URLQueryItem(name: $0.key,
-                                                       value: $0.value)}
+        queryItems = parameters.map { URLQueryItem(name: $0.key,
+                                                   value: $0.value) }
     }
 }

--- a/Sources/NetworkKit/URLRequest.swift
+++ b/Sources/NetworkKit/URLRequest.swift
@@ -9,23 +9,22 @@
 import Foundation
 
 public extension URLRequest {
-        
     private func percentEscapeString(_ string: String) -> String {
         var characterSet = CharacterSet.alphanumerics
         characterSet.insert(charactersIn: "-._*")
-        
+
         return string
             .addingPercentEncoding(withAllowedCharacters: characterSet)!
             .replacingOccurrences(of: " ", with: "+")
             .replacingOccurrences(of: " ", with: "+", options: [], range: nil)
     }
-    
-    public mutating func encodeParameters(parameters: [String: String]) {
+
+    mutating func encodeParameters(parameters: [String: String]) {
         let parameterArray = parameters.map { (arg) -> String in
             let (key, value) = arg
             return "\(key)=\(self.percentEscapeString(value))"
         }
-        
+
         httpBody = parameterArray.joined(separator: "&").data(using: .utf8)
     }
 }

--- a/Sources/NetworkKit/WebServiceProtocol.swift
+++ b/Sources/NetworkKit/WebServiceProtocol.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 public protocol WebServiceProtocol {
-    
     var baseURL: URL { get set }
     var headerValues: HTTPHeaders { get set }
     var urlSession: URLSession { get }
@@ -17,10 +16,9 @@ public protocol WebServiceProtocol {
     var parser: ParserProtocol { get }
 }
 
+// MARK: Requet Utility
 
-//MARK: Requet Utility
 public extension WebServiceProtocol {
-    
     func buildRequest(withPath path: String,
                       method: HTTPMethod,
                       bodyType: HTTPBodyType = .none,
@@ -28,46 +26,46 @@ public extension WebServiceProtocol {
                       queryParameters query: QueryParameters? = nil) -> URLRequest? {
         guard
             var components = URLComponents(string: baseURL.absoluteString + path)
-            else { return nil }
-        
+        else { return nil }
+
         if let queryParameters = query {
             components.setQueryItems(with: queryParameters)
         }
         guard let url = components.url else { return nil }
         return buildRequest(withUrl: url, method: method, bodyType: bodyType, body: body)
     }
-    
+
     private func buildRequest(withUrl url: URL,
                               method: HTTPMethod,
                               bodyType: HTTPBodyType = .none,
                               body: Encodable? = nil) -> URLRequest? {
-        
         var request = URLRequest(url: url)
         request.httpMethod = method.value
-        
+
         if !headerValues.isEmpty {
-            headerValues.forEach{request.setValue($0.value, forHTTPHeaderField: $0.key)}
+            headerValues.forEach { request.setValue($0.value, forHTTPHeaderField: $0.key) }
         }
-        
+
         switch bodyType {
         case .none:
             break
-        case .formEncoded(parameters: let parameters):
+        case let .formEncoded(parameters: parameters):
             request.encodeParameters(parameters: parameters)
         case .json:
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = body?.encode()
         }
-        
+
         return request
     }
 }
 
-//MARK: URLSession Utility
+// MARK: URLSession Utility
+
 public extension WebServiceProtocol {
-    
     func perfomDataTask(withRequest request: URLRequest, completion: @escaping TaskCallback) {
         networkActivity.increment()
-        urlSession.dataTask(with: request, completionHandler: { (data, response, error) in
+        urlSession.dataTask(with: request, completionHandler: { data, response, error in
             self.networkActivity.decrement()
             completion(data, response, error)
         }).resume()

--- a/Tests/NetworkKitTests/XCTestManifests.swift
+++ b/Tests/NetworkKitTests/XCTestManifests.swift
@@ -1,9 +1,9 @@
 import XCTest
 
 #if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(NetworkKitTests.allTests),
-    ]
-}
+    public func allTests() -> [XCTestCaseEntry] {
+        return [
+            testCase(NetworkKitTests.allTests),
+        ]
+    }
 #endif


### PR DESCRIPTION
- added tests hitting httpbin.org 
- added a Response wrapper object that encapsulates the URLRequest, URLResponse, and the Result of the json decode or data. For example now the client can access the status code if needed
- ran the project through [swiftformat](https://github.com/nicklockwood/SwiftFormat) with default ruleset 