### PR TITLE
Better validation and custom error parsing

### DIFF
--- a/Examples/NetworkKitDemo/NetworkKitDemo/ViewController.swift
+++ b/Examples/NetworkKitDemo/NetworkKitDemo/ViewController.swift
@@ -84,12 +84,13 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegate {
 
         cell.backgroundColor = .black
 
-        let urlString = "https://robohash.org/\(indexPath.row)?size=40x40"
+        let urlString = "https://robohash.org/\(indexPath.row)?size=400x400"
 
         cell.imageView.loadImage(from: urlString, placeHolder: UIImage(named: "0"))
         return cell
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        collectionView.reloadData()
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,65 @@
 
 This package provides basic Networking.
 
-## Usage
+### Usage
+
+#### Request
+
+You can make requests on the shared `Network` object at `NK` or create your own `Network`. For example if you wanted to request a decoded `User` object, you could do:
+
+```swift
+NK.request(UsersAPI.getUser(id: 123)).responseDecoded(of: User.self) { response in
+    switch response.result {
+    case let .success(data):
+        print("success \(data)")
+    case let .failure(error):
+        print("error: \(error)")
+    }
+}
+```
+You can request a urlString, URL, URLRequest or a TargetType:
+
+```swift
+NK.request("http://google")
+NK.request(URL(string: "http://google"))
+NK.request(URLRequest(url: URL(string:"http://google")))
+NK.request(target)
+```
+
+You can also do `.response` if you just want the data, or `.responseString` if you want a string
+
+### Response
+
+The type of object you get back from a response is Response<SomeModel>, which is a wrapper around the Result<SomeModel, NetworkError> and holds everything you might need about the response, such as the originating URLRequest, the URLResponse object and raw data.
+
+```swift
+public struct Response<Success, Failure: Error> {
+    public var request: URLRequest?
+    public var response: URLResponse?
+
+    public var data: Data?
+    public let result: Result<SuccessType, NetworkError>
+}
+
+extension Response {
+    public var statusCode: Int?
+    public func localizedStringForStatusCode() -> String? 
+    public var allHeaderFields: [AnyHashable: Any]? 
+}
+```
+
+To cancel a request, hold on to the `Request` object and cancel it whenever.
+
+```swift
+let request = NK.request(UsersAPI.getUsers)
+request.response { response in 
+// blabla
+}
+
+request.cancel()
+```
+
+### TargetType
 
 Create an object that conforms to TargetType to define the HTTP details of your API's endpoints 
 
@@ -61,58 +119,40 @@ extension UsersAPI: TargetType {
 
 ```
 
-## Request
+### Validation
 
-You can make requests on the shared `Network` object at `NK` or create your own `Network`. For example if you wanted to request a decoded `User` object, you could do:
+You can validate requests after the response if you need to define what counts as an error, for example if the HTTP status code is not 200. You can chain multiple validations, custom or not 
+
 
 ```swift
-NK.request(UsersAPI.getUser(id: 123)).responseDecoded(of: User.self) { response in
-    switch response.result {
-    case let .success(data):
-        print("success \(data)")
-    case let .failure(error):
-        print("error: \(error)")
-    }
+NK.request(UserAPI.getUser("bob").validate().responseDecoded(of: TestModel.self) { response in
+    
 }
-```
-You can request a urlString, URL, URLRequest or a TargetType:
 
-```swift
-NK.request("http://google")
-NK.request(URL(string: "http://google"))
-NK.request(URLRequest(url: URL(string:"http://google")))
-NK.request(target)
 ```
 
-You can also do `.response` if you just want the data, or `.responseString` if you want a string
+### Custom error parsing
 
-## Response
+If your server returns different schemas on errors that you'd like to parse, you can supply a type that will be used to parse that, in the cases when validation fails.
 
-The type of object you get back from a response is Response<SomeModel>, which is a wrapper around the Result<SomeModel, NetworkError> and holds everything you might need about the response, such as the originating URLRequest, the URLResponse object and raw data.
-
-```swift
-public struct Response<Success, Failure: Error> {
-    public var request: URLRequest?
-    public var response: URLResponse?
-
-    public var data: Data?
-    public let result: Result<SuccessType, NetworkError>
-}
-
-extension Response {
-    public var statusCode: Int?
-    public func localizedStringForStatusCode() -> String? 
-    public var allHeaderFields: [AnyHashable: Any]? 
-}
-```
-
-To cancel a request, hold on to the `Request` object and cancel it whenever.
+So for example if you are calling an authorization server that returns status code 401 and some json describing the error, you can parse that and get it in the NetworkError
 
 ```swift
-let request = NK.request(UsersAPI.getUsers)
-request.response { response in 
-// blabla
+
+network?.request(AuthAPI.authenticate(with: credentials))
+    .validate()
+    .responseDecoded(of: AuthState.self,
+                     errorType: AuthError.self) { response in
+
+        switch response.result {
+        case .success:
+            // do fun stuff
+        case let .failure(error):
+            // get the AuthError object
+            if case let .errorResponse(errorObject) = error {
+                // do fun stuff with your AuthError object
+            }
+        }
 }
 
-request.cancel()
 ```

--- a/README.md
+++ b/README.md
@@ -156,3 +156,30 @@ network?.request(AuthAPI.authenticate(with: credentials))
 }
 
 ```
+
+### Request Adaptors
+
+If you'd like to adapt the URLRequest before transport, you can pass in a RequestAdaptor to your request, for example if you'd like to add runtime authentication headers:
+
+```swift
+public struct AuthenticationAdapter: RequestAdapter {
+    let accessToken: AccessToken
+
+    public func adapt(_ urlRequest: URLRequest) -> URLRequest {
+        var urlRequest = urlRequest
+        urlRequest.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        return urlRequest
+    }
+}
+
+self.network.request(target)
+    .withAdapter(AuthenticationAdapter(accessToken: accessToken))
+    .responseDecoded(of: T.self) { response in
+        switch response.result {
+        case let .success(products):
+            completion(.success(products))
+        case let .failure(error):
+            completion(.failure(ApplicationError.networkError(error)))
+        }
+}
+```

--- a/Sources/NetworkKit/Endpoint.swift
+++ b/Sources/NetworkKit/Endpoint.swift
@@ -25,7 +25,7 @@ public enum NetworkError: Error {
     case responseError(Error)
     case dataMissing
     case responseMissing
-    case errorResponse(Decodable?)
+    case errorResponse(Decodable)
     case middlewareError(Error)
     case validateError
     case cancelled
@@ -45,16 +45,10 @@ public struct Response<SuccessType> {
     public var response: URLResponse?
 
     public var data: Data?
-    public let result: Result<SuccessType, NetworkError>
+    public var result: Result<SuccessType, NetworkError>
+    public var responseIsFromCacheProvider: Bool = false
 
     init(_ result: Result<SuccessType, NetworkError>) {
-        self.result = result
-    }
-
-    init(request: URLRequest?, response: URLResponse?, data: Data?, result: Result<SuccessType, NetworkError>) {
-        self.request = request
-        self.response = response
-        self.data = data
         self.result = result
     }
 }

--- a/Sources/NetworkKit/NetworkKit.swift
+++ b/Sources/NetworkKit/NetworkKit.swift
@@ -4,21 +4,20 @@ import Foundation
 // swiftlint:disable:next type_name
 public enum NK {
     public static var sharedNetwork = Network()
-    public static func request(withBaseURL baseURL: URL,
-                               path: String,
+    public static func request(URL: URL,
                                method: HTTPMethod,
                                bodyType: HTTPBodyType = .none,
                                headerValues: HTTPHeaders? = nil,
                                body: Encodable? = nil,
                                queryParameters query: QueryParameters? = nil) -> Request {
 
-        return NK.sharedNetwork.request(URLRequest(baseURL: baseURL,
-                                                path: path,
-                                                httpMethod: method,
-                                                headerValues: headerValues,
-                                                queryParameters: query,
-                                                bodyType: bodyType,
-                                                body: body))
+        return NK.sharedNetwork.request(URLRequest(baseURL: URL,
+                                                   path: "",
+                                                   httpMethod: method,
+                                                   headerValues: headerValues,
+                                                   queryParameters: query,
+                                                   bodyType: bodyType,
+                                                   body: body))
     }
 
     public static func request(_ target: TargetType) -> Request {

--- a/Sources/NetworkKit/RemoteImage.swift
+++ b/Sources/NetworkKit/RemoteImage.swift
@@ -77,6 +77,8 @@ public extension URLSessionDataRequest {
     @discardableResult
     func responseImage(completion: @escaping ResponseCallback<UIImage>) -> Self {
 
+        startTask()
+
         self.addParseOperation(parser: ImageParser()) { response in
             OperationQueue.main.addOperation {
                 completion(response)

--- a/Sources/NetworkKit/Request.swift
+++ b/Sources/NetworkKit/Request.swift
@@ -14,259 +14,31 @@ public protocol RequestAdapter {
 }
 
 public protocol Request: RequestResponses {
+    /// the URLRequest that was sent out
     var urlRequest: URLRequest? { get }
-    var response: URLResponse? { get }
-    var data: Data? { get }
-    var error: Error? { get }
-    var isSuccess: Bool { get }
 
+    /// the URLResponse returned. could be a HTTPURLResponse if using URLSessionDataRequest
+    var response: URLResponse? { get }
+
+    /// the final collection of data returned
+    var data: Data? { get }
+
+    /// if an error was encountered, this will have the error
+    var error: NetworkError? { get }
+
+    /// allows the URLRequest to be adapted before transport
     var adapters: [RequestAdapter] { get }
     func withAdapter(_ adapter: RequestAdapter) -> Self
 
+    /// validates using the default response validator (checking if status code is 200...299
     func validate() -> Self
+
+    /// validates with the given ResponseValidator
+    func validate(with validator: ResponseValidator) -> Self
+
+    /// validates with the given block
+    func validate(_ successBlock: @escaping ValidationBlock) -> Self
+
+    /// cancels the request
     func cancel()
-}
-
-public class URLSessionDataRequest: NSObject, Request {
-    let queue = DispatchQueue(label: "no.shortcut.NetworkKit.Requests", qos: .background, attributes: .concurrent)
-    private var operationQueue = OperationQueue()
-
-    private var workItems = [DispatchWorkItem]()
-
-    let defaultParser: DecodableParserProtocol
-    public var urlRequest: URLRequest?
-    public let urlSession: URLSession
-
-    var task: URLSessionTask?
-    public var taskCreation: ((URLSessionTask) -> Void)?
-
-    private var receivedData: Data? = Data()
-    public var data: Data?
-    public var error: Error?
-
-    public var adapters = [RequestAdapter]()
-
-    public var response: URLResponse?
-    public var isSuccess: Bool = true
-    private var shouldValidate: Bool = false
-
-    private var isCancelled = false
-
-    var cacheProvider: CacheProvider
-
-    public init(urlSession: URLSession,
-                urlRequest: URLRequest?,
-                cacheProvider: CacheProvider,
-                defaultParser: DecodableParserProtocol) {
-        self.cacheProvider = cacheProvider
-        self.urlSession = urlSession
-        self.urlRequest = urlRequest
-        self.defaultParser = defaultParser
-        super.init()
-    }
-
-    private func prepareTask() {
-        operationQueue.isSuspended = true
-
-        guard var urlRequest = urlRequest else {
-            return
-        }
-
-        for adapter in adapters {
-            urlRequest = adapter.adapt(urlRequest)
-        }
-
-        self.urlRequest = urlRequest
-
-        let task = urlSession.dataTask(with: urlRequest)
-        self.task = task
-        taskCreation?(task)
-        taskCreation = nil
-    }
-
-    public func withAdapter(_ adapter: RequestAdapter) -> Self {
-        adapters.append(adapter)
-        return self
-    }
-
-    public func cancel() {
-        isCancelled = true
-        task?.cancel()
-    }
-
-    func completeWithCache<Parser: ResponseParser>(parser: Parser,
-                                                   block: @escaping ResponseCallback<Parser.ParsedObject>) -> Bool {
-        // check cache and return early
-        // swiftlint:disable:next todo
-        // TODO: need to check cachePolicy better
-        if let urlRequest = self.urlRequest,
-            let cacheItem = self.cacheProvider.getCache(for: urlRequest),
-            urlRequest.cachePolicy == .returnCacheDataElseLoad,
-            let cacheObject = cacheItem.object as? Parser.ParsedObject {
-            let result = .success(cacheObject) as Result<Parser.ParsedObject, NetworkError>
-
-            OperationQueue.main.addOperation {
-                block(self.responseWithResult(result))
-            }
-            return true
-        }
-
-        return false
-    }
-
-    func addParseOperation<Parser: ResponseParser>(parser: Parser,
-                                                   block: @escaping ResponseCallback<Parser.ParsedObject>) {
-
-        // try our cache, return early if we gots it
-        queue.sync {
-            if completeWithCache(parser: parser, block: block) {
-                return
-            }
-        }
-
-        // get everything ready for this request
-        prepareTask()
-
-        guard let urlRequest = urlRequest else {
-            block(responseWithResult(.failure(.invalidURL)))
-            return
-        }
-
-        // no cache, so start network requests if not already started
-        startTask()
-
-        operationQueue.addOperation {
-
-            // check if cancelled (not sure this ever does anything actually)
-            if self.error == nil,
-                self.isCancelled == true ||
-                    self.task?.state == .canceling {
-                block(self.responseWithResult(.failure(.cancelled)))
-                print("cancelled \(self.debugDescription)")
-                return
-            }
-
-            // URLSession network error? always fail
-            if let error = self.error {
-                print("error \(error)")
-                block(self.responseWithResult(.failure(.responseError(error))))
-                return
-            }
-
-            // validation error? fail.
-            if self.shouldValidate && !self.isSuccess {
-                block(self.responseWithResult(.failure(NetworkError.validateError)))
-                return
-            }
-
-            // finally try to parse
-            let result = self.parseResponse(urlRequest: urlRequest, data: self.data, parser: parser).mapError { error in
-                NetworkError.parsingError(error)
-            }
-            block(self.responseWithResult(result))
-
-            // save to cache
-            self.queue.async {
-                if let urlRequest = self.urlRequest,
-                    case let .success(object) = result {
-                    self.cacheProvider.setCache(for: urlRequest, data: self.data, object: object)
-                }
-            }
-        }
-    }
-
-    public func validate() -> Self {
-        shouldValidate = true
-        return self
-    }
-
-    private func parseResponse<Parser: ResponseParser>(urlRequest: URLRequest,
-                                                       data: Data?,
-                                                       parser: Parser) -> Result<Parser.ParsedObject, ParserError> {
-        guard let data = data else {
-            return .failure(.dataMissing)
-        }
-
-        return parser.parse(data: data, type: Parser.ParsedObject.self)
-    }
-
-    private func startTask() {
-        // swiftlint:disable:next todo
-        // TODO: better state management
-        if let task = task,
-            task.state != .running,
-            task.state != .canceling,
-            task.state != .completed,
-            isCancelled == false {
-
-            urlSession.delegateQueue.addOperation {
-                task.resume()
-            }
-        }
-    }
-
-    private func finish() {
-        // swiftlint:disable:next todo
-        // TODO: custom validation
-        if let statusCode = statusCode {
-            isSuccess = (statusCode < 400)
-        }
-
-        operationQueue.isSuspended = false
-    }
-
-    private func responseWithResult<ParsedObject>(
-        _ result: Result<ParsedObject, NetworkError>) -> Response<ParsedObject> {
-        var response = Response(result)
-        response.data = self.data
-        response.response = self.response
-        response.request = self.urlRequest
-
-        return response
-    }
-}
-
-public extension URLSessionDataRequest {
-    var statusCode: Int? {
-        guard let response = self.response as? HTTPURLResponse else { return nil }
-        return response.statusCode
-    }
-
-    func localizedStringForStatusCode() -> String? {
-        guard let statusCode = self.statusCode else { return nil }
-        return HTTPURLResponse.localizedString(forStatusCode: statusCode)
-    }
-
-    var allHeaderFields: [AnyHashable: Any]? {
-        guard let response = self.response as? HTTPURLResponse else { return nil }
-        return response.allHeaderFields
-    }
-}
-
-extension URLSessionDataRequest: URLSessionDataDelegate {
-    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-        self.receivedData?.append(data)
-    }
-
-    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        self.error = error
-        if let receivedData = self.receivedData,
-            receivedData.count > 0 {
-            self.data = self.receivedData
-            self.receivedData = nil
-        }
-        finish()
-    }
-
-    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask,
-                           didReceive response: URLResponse,
-                           completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
-        self.response = response as? HTTPURLResponse
-        completionHandler(.allow)
-    }
-
-    public func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
-        self.error = error
-        finish()
-    }
 }

--- a/Sources/NetworkKit/Responses.swift
+++ b/Sources/NetworkKit/Responses.swift
@@ -8,20 +8,35 @@
 import Foundation
 
 public protocol RequestResponses {
+    /// returns the raw data from the request
     @discardableResult
     func response(_ completion: @escaping ResponseCallback<Data>) -> Self
 
+    /// returns the response back as a string
     @discardableResult
     func responseString(_ completion: @escaping ResponseCallback<String>) -> Self
 
+    /// returns the JSON dictionary from the response
     @discardableResult
     func responseJSON(options: JSONSerialization.ReadingOptions,
                       completion: @escaping ResponseCallback<Any>) -> Self
 
+    /// returns a decoded object of the specified type with the given parser
     @discardableResult
     func responseDecoded<T: Decodable>(of type: T.Type,
                                        parser: DecodableParserProtocol?,
                                        completion: @escaping ResponseCallback<T>) -> Self
+
+    /// returns a decoded object of the specified type with the given parser
+    /// or... a decoded error object in the network error if the response failed validation
+    ///
+    /// for example... if the server returns a json error that you want to parse, you'll find the passed errorType in
+    /// NetworkError.responseError(Decodable?)
+    @discardableResult
+    func responseDecoded<T: Decodable, E: Decodable>(of type: T.Type,
+                                                     errorType: E.Type,
+                                                     parser: DecodableParserProtocol?,
+                                                     completion: @escaping ResponseCallback<T>) -> Self
 }
 
 public extension RequestResponses {
@@ -31,6 +46,15 @@ public extension RequestResponses {
                                        parser: DecodableParserProtocol? = nil,
                                        completion: @escaping ResponseCallback<T>) -> Self {
         self.responseDecoded(of: type, parser: parser, completion: completion)
+        return self
+    }
+
+    @discardableResult
+    func responseDecoded<T: Decodable, E: Decodable>(of type: T.Type = T.self,
+                                                     errorType: E.Type = E.self,
+                                                     parser: DecodableParserProtocol? = nil,
+                                                     completion: @escaping ResponseCallback<T>) -> Self {
+        self.responseDecoded(of: type, errorType: errorType, parser: parser, completion: completion)
         return self
     }
 
@@ -45,6 +69,8 @@ public extension RequestResponses {
 extension URLSessionDataRequest: RequestResponses {
     @discardableResult
     public func response(_ completion: @escaping ResponseCallback<Data>) -> Self {
+        startTask()
+
         addParseOperation(parser: DataParser()) { response in
             OperationQueue.main.addOperation {
                 completion(response)
@@ -56,6 +82,8 @@ extension URLSessionDataRequest: RequestResponses {
 
     @discardableResult
     public func responseString(_ completion: @escaping ResponseCallback<String>) -> Self {
+        startTask()
+
         addParseOperation(parser: StringParser()) { response in
             OperationQueue.main.addOperation {
                 completion(response)
@@ -69,6 +97,8 @@ extension URLSessionDataRequest: RequestResponses {
     public func responseDecoded<T: Decodable>(of type: T.Type = T.self,
                                               parser: DecodableParserProtocol? = nil,
                                               completion: @escaping ResponseCallback<T>) -> Self {
+        startTask()
+
         let parser = parser ?? self.defaultParser
 
         self.addParseOperation(parser: DecodableParser<T>(parser: parser)) { response in
@@ -81,8 +111,47 @@ extension URLSessionDataRequest: RequestResponses {
     }
 
     @discardableResult
+    public func responseDecoded<T: Decodable, E: Decodable>(of type: T.Type = T.self,
+                                                            errorType: E.Type = E.self,
+                                                            parser: DecodableParserProtocol? = nil,
+                                                            completion: @escaping ResponseCallback<T>) -> Self {
+        startTask()
+
+        let parser = parser ?? self.defaultParser
+
+        afterRequestQueue.addOperation {
+            if self.error == nil {
+                self.addParseOperation(parser: DecodableParser<T>(parser: parser)) { response in
+                    OperationQueue.main.addOperation {
+                        completion(response)
+                    }
+                }
+            } else if let error = self.error,
+                case .validateError = error {
+                self.afterRequestQueue.addOperation {
+                    let result: Result<E, ParserError> = parser.parse(data: self.data)
+                    var networkResult: Result<T, NetworkError>
+                    if let errorObject = try? result.get() {
+                        networkResult = .failure(.errorResponse(errorObject))
+                    } else {
+                        networkResult = .failure(error)
+                    }
+
+                    OperationQueue.main.addOperation {
+                        completion(self.responseWithResult(networkResult))
+                    }
+                }
+            }
+        }
+
+        return self
+    }
+
+    @discardableResult
     public func responseJSON(options: JSONSerialization.ReadingOptions = .allowFragments,
                              completion: @escaping ResponseCallback<Any>) -> Self {
+        startTask()
+
         self.addParseOperation(parser: JSONParser()) { response in
             OperationQueue.main.addOperation {
                 completion(response)

--- a/Sources/NetworkKit/TargetType.swift
+++ b/Sources/NetworkKit/TargetType.swift
@@ -18,7 +18,9 @@ public protocol TargetType {
     var queryParameters: QueryParameters? { get }
     var cachePolicy: URLRequest.CachePolicy { get }
 
-    var diskPath: String? { get } // for mocks using DiskRequest
+    // for mocks using DiskRequest
+    var diskPath: String? { get }
+    var diskPathErrorModel: String? { get }
     var diskDelay: TimeInterval { get }
 }
 
@@ -30,6 +32,7 @@ public extension TargetType {
     var headerValues: HTTPHeaders? { nil }
     var cachePolicy: URLRequest.CachePolicy { .useProtocolCachePolicy }
     var diskPath: String? { nil }
+    var diskPathErrorModel: String? { nil }
     var diskDelay: TimeInterval { 0 }
 }
 

--- a/Sources/NetworkKit/URLSessionDataRequest.swift
+++ b/Sources/NetworkKit/URLSessionDataRequest.swift
@@ -1,0 +1,238 @@
+//
+//  File.swift
+//  
+//
+//  Created by Andre Navarro on 12/20/19.
+//
+
+import Foundation
+
+/// main implementation of a Request that uses URLSession
+/// best to be used as part of a Network
+public class URLSessionDataRequest: NSObject, Request {
+    internal let queue = DispatchQueue(label: "no.shortcut.NetworkKit.Requests",
+                                       qos: .background,
+                                       attributes: .concurrent)
+    internal var afterRequestQueue: OperationQueue = {
+        let operationQueue = OperationQueue()
+        operationQueue.maxConcurrentOperationCount = 1
+        operationQueue.isSuspended = true
+        return operationQueue
+    }()
+
+    internal let defaultParser: DecodableParserProtocol
+    public var urlRequest: URLRequest?
+    public let urlSession: URLSession
+    public var response: URLResponse?
+
+    internal var task: URLSessionTask?
+    internal var taskCreation: ((URLSessionTask) -> Void)?
+
+    private var receivedData: Data? = Data()
+    public var data: Data?
+    public var error: NetworkError?
+
+    public var adapters = [RequestAdapter]()
+
+    internal var isCancelled = false
+
+    var cacheProvider: CacheProvider
+    var cachedItem: CacheItem?
+
+    public init(urlSession: URLSession,
+                urlRequest: URLRequest?,
+                cacheProvider: CacheProvider,
+                defaultParser: DecodableParserProtocol) {
+        self.cacheProvider = cacheProvider
+        self.urlSession = urlSession
+        self.urlRequest = urlRequest
+        self.defaultParser = defaultParser
+        super.init()
+    }
+
+    internal func prepareTask() {
+        guard var urlRequest = urlRequest else {
+            self.error = NetworkError.invalidURL
+            return
+        }
+
+        for adapter in adapters {
+            urlRequest = adapter.adapt(urlRequest)
+        }
+
+        self.urlRequest = urlRequest
+    }
+
+    public func withAdapter(_ adapter: RequestAdapter) -> Self {
+        adapters.append(adapter)
+        return self
+    }
+
+    public func cancel() {
+        isCancelled = true
+        task?.cancel()
+    }
+
+    func checkCache() -> CacheItem? {
+        // swiftlint:disable:next todo
+        // TODO: need to check cachePolicy in a better way, maybe have our own enum
+        if let urlRequest = self.urlRequest,
+            let cacheItem = self.cacheProvider.getCache(for: urlRequest),
+            urlRequest.cachePolicy == .returnCacheDataElseLoad {
+            return cacheItem
+        }
+
+        return nil
+    }
+
+    internal func addParseOperation<Parser: ResponseParser>(parser: Parser,
+                                                            block: @escaping ResponseCallback<Parser.ParsedObject>) {
+
+        // check if we have a cache item and return early
+        if let cachedItem = self.cachedItem,
+            let cachedObject = cachedItem.object as? Parser.ParsedObject {
+
+            let result = Result<Parser.ParsedObject, NetworkError>.success(cachedObject)
+            block(self.responseWithResult(result))
+            return
+        }
+
+        // no cache, so parse whatever network request comes in
+        afterRequestQueue.addOperation {
+            guard self.urlRequest != nil else {
+                self.error = NetworkError.invalidURL
+                return
+            }
+
+            if let error = self.error {
+                let result = Result<Parser.ParsedObject, NetworkError>.failure(error)
+                block(self.responseWithResult(result))
+                return
+            }
+
+            // finally try to parse
+            let result = self.parseResponse(data: self.data, parser: parser).mapError { error in
+                NetworkError.parsingError(error)
+            }
+            block(self.responseWithResult(result))
+
+            // save to cache
+            self.queue.async {
+                if let urlRequest = self.urlRequest,
+                    case let .success(object) = result {
+                    self.cacheProvider.setCache(for: urlRequest, data: self.data, object: object)
+                }
+            }
+        }
+    }
+
+    internal func parseResponse<Parser: ResponseParser>(data: Data?,
+                                                        parser: Parser) -> Result<Parser.ParsedObject, ParserError> {
+        guard let data = data else {
+            return .failure(.dataMissing)
+        }
+
+        return parser.parse(data: data, type: Parser.ParsedObject.self)
+    }
+
+    internal func startTask() {
+        prepareTask()
+
+        // try our cache, return early if we gots it
+        if let cacheItem = checkCache() {
+            self.cachedItem = cacheItem
+            finish()
+            return
+        }
+
+        guard let urlRequest = urlRequest else {
+            self.error = NetworkError.invalidURL
+            return
+        }
+
+        let task = urlSession.dataTask(with: urlRequest)
+        self.task = task
+        taskCreation?(task)
+        taskCreation = nil
+
+        // swiftlint:disable:next todo
+        // TODO: better state management
+        if task.state != .running,
+            task.state != .canceling,
+            task.state != .completed,
+            isCancelled == false {
+
+            // resume iz expensive, let's do it in the background
+            urlSession.delegateQueue.addOperation {
+                task.resume()
+            }
+        }
+    }
+
+    internal func finish() {
+        // request or cache lookup is finished, let the dogs out and validate, parse, etc
+        afterRequestQueue.isSuspended = false
+    }
+
+    internal func responseWithResult<ParsedObject>(
+        _ result: Result<ParsedObject, NetworkError>) -> Response<ParsedObject> {
+        var response = Response(result)
+        response.data = self.data
+        response.response = self.response
+        response.request = self.urlRequest
+        response.responseIsFromCacheProvider = self.cachedItem != nil
+
+        return response
+    }
+}
+
+public extension URLSessionDataRequest {
+    var statusCode: Int? {
+        guard let response = self.response as? HTTPURLResponse else { return nil }
+        return response.statusCode
+    }
+
+    func localizedStringForStatusCode() -> String? {
+        guard let statusCode = self.statusCode else { return nil }
+        return HTTPURLResponse.localizedString(forStatusCode: statusCode)
+    }
+
+    var allHeaderFields: [AnyHashable: Any]? {
+        guard let response = self.response as? HTTPURLResponse else { return nil }
+        return response.allHeaderFields
+    }
+}
+
+extension URLSessionDataRequest: URLSessionDataDelegate {
+    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        self.receivedData?.append(data)
+    }
+
+    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let error = error {
+            self.error = .responseError(error)
+        }
+
+        if let receivedData = self.receivedData,
+            receivedData.count > 0 {
+            self.data = self.receivedData
+            self.receivedData = nil
+        }
+        finish()
+    }
+
+    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask,
+                           didReceive response: URLResponse,
+                           completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        self.response = response as? HTTPURLResponse
+        completionHandler(.allow)
+    }
+
+    public func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
+        if let error = error {
+            self.error = .responseError(error)
+        }
+
+        finish()
+    }
+}

--- a/Sources/NetworkKit/URLSessionDataRequest.swift
+++ b/Sources/NetworkKit/URLSessionDataRequest.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  URLSessionDataRequest.swift
 //  
 //
 //  Created by Andre Navarro on 12/20/19.

--- a/Sources/NetworkKit/Validation.swift
+++ b/Sources/NetworkKit/Validation.swift
@@ -1,0 +1,66 @@
+//
+//  File.swift
+//  
+//
+//  Created by Andre Navarro on 12/19/19.
+//
+
+import Foundation
+
+public typealias ValidationBlock = (Data?, URLResponse?, Error?) -> Bool
+
+public protocol ResponseValidator {
+    func validate(data: Data?, urlResponse: URLResponse?, error: Error?) -> Bool
+}
+
+/// for use with mocks or tests that want to fail validation
+struct FailValidator: ResponseValidator {
+    func validate(data: Data?, urlResponse: URLResponse?, error: Error?) -> Bool {
+        false
+    }
+}
+
+/// most common validation, checking status code between 200 and 299
+struct DefaultResponseValidator: ResponseValidator {
+    fileprivate var acceptableStatusCodes: Range<Int> { return 200..<300 }
+
+    func validate(data: Data?, urlResponse: URLResponse?, error: Error?) -> Bool {
+        if let response = urlResponse as? HTTPURLResponse {
+            return acceptableStatusCodes.contains(response.statusCode)
+        }
+
+        return true
+    }
+}
+
+extension URLSessionDataRequest {
+    public func validate(with validator: ResponseValidator) -> Self {
+        afterRequestQueue.addOperation {
+            if !validator.validate(data: self.data, urlResponse: self.response, error: self.error) {
+                self.error = NetworkError.validateError
+            }
+        }
+
+        return self
+    }
+
+    public func validate(_ successBlock: @escaping ValidationBlock) -> Self {
+        afterRequestQueue.addOperation {
+            if !successBlock(self.data, self.response, self.error) {
+                self.error = NetworkError.validateError
+            }
+        }
+
+        return self
+    }
+
+    public func validate() -> Self {
+        afterRequestQueue.addOperation {
+            if !DefaultResponseValidator().validate(data: self.data, urlResponse: self.response, error: self.error) {
+                self.error = NetworkError.validateError
+            }
+        }
+
+        return self
+    }
+}

--- a/Sources/NetworkKit/Validation.swift
+++ b/Sources/NetworkKit/Validation.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Validation.swift
 //  
 //
 //  Created by Andre Navarro on 12/19/19.

--- a/Tests/NetworkKitTests/NetworkTests.swift
+++ b/Tests/NetworkKitTests/NetworkTests.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  NetworkTests.swift
 //  
 //
 //  Created by Andre Navarro on 10/21/19.

--- a/Tests/NetworkKitTests/NetworkTests.swift
+++ b/Tests/NetworkKitTests/NetworkTests.swift
@@ -92,10 +92,12 @@ final class NetworkTests: XCTestCase {
         wait(for: [expectation], timeout: 5)
     }
 
-    func testErrorClient() {
+    func testDefaultValidation() {
         let expectation = XCTestExpectation(description: "should fail after a request that returns code 500")
 
         network?.request(HTTPStatusService.fiveHundred).validate().responseDecoded(of: TestModel.self) { response in
+            XCTAssertTrue(Thread.isMainThread)
+
             switch response.result {
             case .success:
                 XCTFail("shouldn't succeed")
@@ -104,6 +106,77 @@ final class NetworkTests: XCTestCase {
             }
 
             expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5)
+    }
+
+    func testBlockValidation() {
+        let expectation = XCTestExpectation(description: "should fail after a request that returns code 500")
+
+        network?.request(HTTPStatusService.fiveHundred).validate({ (_, response, _) -> Bool in
+            if let response = response as? HTTPURLResponse,
+                response.statusCode == 500 {
+                // should be status 500
+            } else {
+                XCTFail("should have a HTTP response and status code")
+            }
+            return false
+        }).responseDecoded(of: TestModel.self) { response in
+            XCTAssertTrue(Thread.isMainThread)
+
+            switch response.result {
+            case .success:
+                XCTFail("shouldn't succeed")
+            case let .failure(error):
+                print(error)
+            }
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5)
+    }
+
+    func testValidationWithValidator() {
+        let expectation = XCTestExpectation(description: "should fail after a request that returns code 500")
+
+        network?.request(HTTPStatusService.fiveHundred)
+            .validate(with: FailValidator()).responseDecoded(of: TestModel.self) { response in
+            XCTAssertTrue(Thread.isMainThread)
+
+            switch response.result {
+            case .success:
+                XCTFail("shouldn't succeed")
+            case let .failure(error):
+                print(error)
+            }
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5)
+    }
+
+    func testErrorResponse() {
+        let expectation = XCTestExpectation(description: "should parse error model as error")
+
+        network?.request(HTTPStatusService.fiveHundred)
+            .validate()
+            .responseDecoded(of: TestModel.self,
+                             errorType: TestErrorModel.self) { response in
+                XCTAssertTrue(Thread.isMainThread)
+
+                switch response.result {
+                case .success:
+                    XCTFail("shouldn't succeed")
+                case let .failure(error):
+                    if case let .errorResponse(errorObject) = error,
+                        errorObject is TestErrorModel {
+                        expectation.fulfill()
+                    }
+                    print(error)
+                }
         }
 
         wait(for: [expectation], timeout: 5)


### PR DESCRIPTION
### Validation #18 

You can validate requests after the response if you need to define what counts as an error, for example if the HTTP status code is not 200. 


```swift
NK.request(UserAPI.getUser("bob").validate().responseDecoded(of: TestModel.self) { response in
    
}

```

### Custom error parsing

If your server returns different schemas on errors that you'd like to parse, you can supply a type that will be used to parse that, in the cases when validation fails.

So for example if you are calling an authorization server that returns status code 401 and some json describing the error, you can parse that and get it in the NetworkError

```swift

network?.request(AuthAPI.authenticate(with: credentials))
    .validate()
    .responseDecoded(of: AuthState.self,
                     errorType: AuthError.self) { response in

        switch response.result {
        case .success:
            // do fun stuff
        case let .failure(error):
            // get the AuthError object
            if case let .errorResponse(errorObject) = error {
                // do fun stuff with your AuthError object
            }
        }
}

```